### PR TITLE
add --force-color option

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -14,6 +14,7 @@ var (
 	flagQuiet          = flag.Bool("q", false, "do not show logs on stdout")
 	flagMicroseconds   = flag.Bool("m", false, "display time in microseconds")
 	flagDelta          = flag.Bool("delta", false, "show delta time between log entries")
+	flagForceColor     = flag.Bool("force-color", false, "force color output regardless of TTY")
 	flagDirLogs        = flag.String("log-dir", "logs", "logs directory")
 	flagVersion        = flag.Bool("version", false, "display version information")
 )

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,5 @@ go 1.13
 require (
 	github.com/fatih/color v1.9.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/mattn/go-colorable v0.1.2 // indirect
-	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/sirupsen/logrus v1.6.0
-	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,9 @@ go 1.13
 require (
 	github.com/fatih/color v1.9.0
 	github.com/gorilla/websocket v1.4.2
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/sirupsen/logrus v1.6.0
+	golang.org/x/sys v0.0.0-20190927073244-c990c680b611 // indirect
 )

--- a/logger.go
+++ b/logger.go
@@ -187,6 +187,9 @@ func createLogWriter(filename string) (io.Writer, error) {
 }
 
 func createLogger(name string) (*logrus.Logger, error) {
+	if *flagForceColor {
+		color.NoColor = false
+	}
 
 	if _, exists := loggers[name]; !exists {
 		writer, err := createLogWriter(name)


### PR DESCRIPTION
the colors package [doesnt support a force-color env variable](https://github.com/fatih/color/issues/155) but this has the same effect.

i was using this to pipe c-p-p output into `fzf`, which basically served as #3 (the filtering/searching part at least)

FWIW, this was my invocation:

```sh
chrome-protocol-proxy --force-color  | fzf --ansi --tac --bind 'enter:ignore,double-click:ignore'
```